### PR TITLE
Fix `save_filename` undefined when deleting a buffer

### DIFF
--- a/autoload/taglist.vim
+++ b/autoload/taglist.vim
@@ -970,7 +970,11 @@ function! s:Tlist_Remove_File(file_idx, user_request) abort
   let s:tlist_file_count -= 1
 
   if g:Tlist_Show_One_File
-    let s:tlist_cur_file_idx = s:Tlist_Get_File_Index(save_filename)
+    if fidx == s:tlist_cur_file_idx || s:tlist_cur_file_idx == -1
+      let s:tlist_cur_file_idx = -1
+    else
+      let s:tlist_cur_file_idx = s:Tlist_Get_File_Index(save_filename)
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
With this config:
```vim
vim9script
g:Tlist_Show_One_File = 1
g:Tlist_Process_File_Always = 1
```
`:bd` kill a buffer, vim prints this error:
```
Error detected while processing BufDelete Autocommands for "*"..function <SNR>206_Tlist_Buffer_Removed[16]..<SNR>206_Tlist_Remove_File:
line   55:
E121: Undefined variable:
E116: Invalid arguments for function s:Tlist_Get_File_Index(save_filename)
```

This PR uses `save_filename` to set `s:tlist_cur_file_idx` only if it's valid.