### PR TITLE
bugfixed: support non-ascii path under win32 system

### DIFF
--- a/autoload/taglist.vim
+++ b/autoload/taglist.vim
@@ -139,7 +139,8 @@ func! s:OptionsInitDefault()
         \ ['Use_Right_Window', v:false],
         \ ['Use_SingleClick', v:false],
         \ ['WinHeight', 10],
-        \ ['WinWidth', 30]
+        \ ['WinWidth', 30],
+        \ ['Cmd_Encoding', 'default']
         \ ]
   for [name, val] in defvalues
     let optname = 'g:Tlist_' . name
@@ -1777,7 +1778,12 @@ function! s:Tlist_Process_File(filename, ftype) abort
     " and call the batch file.  Do this only on MS-Windows.
     " Contributed by: David Fishburn.
     let taglist_tempfile = fnamemodify(tempname(), ':h') . '\taglist.cmd'
-    call writefile([ctags_cmd], taglist_tempfile, 'b')
+    if has('iconv')
+        let ctags_cmd_codepage = iconv(ctags_cmd, 'UTF-8', g:Tlist_Cmd_Encoding)
+        call writefile([ctags_cmd_codepage], taglist_tempfile, 'b')
+    else
+        call writefile([ctags_cmd], taglist_tempfile, 'b')
+    endif
 
     call s:Tlist_Log_Msg('Cmd inside batch file: ' . ctags_cmd)
     let ctags_cmd = '"' . taglist_tempfile . '"'


### PR DESCRIPTION
For my system (win32/win64)

when using taglist-4.6, `taglist` show nothing when filename or pathname contains non-ascii chars.
after debugging, I found win32 batch file codepage is not UNICODE :(

I work around it, and found ICONV can fix this problem.

```patch
--- taglist.vim
+++ taglist.vim
@@ -1,7 +1,7 @@
 " File: taglist.vim
 " Author: Yegappan Lakshmanan (yegappan AT yahoo DOT com)
-" Version: 4.6
-" Last Modified: Feb 26, 2013
+" Version: 4.6.1
+" Last Modified: Oct 1, 2024
 " Copyright: Copyright (C) 2002-2013 Yegappan Lakshmanan
 "            Permission is hereby granted to use and distribute this code,
 "            with or without modifications, provided that this copyright
@@ -11,6 +11,9 @@
 "            holder be liable for any damamges resulting from the use of this
 "            software.
 "
+" Add iconv convert under win32, support global variable `Tlist_Cmd_Encoding`
+" so this plugin support non-ascii path string
+"
 " The "Tag List" plugin is a source code browser plugin for Vim and provides
 " an overview of the structure of the programming language files and allows
 " you to efficiently browse through source code files for different
@@ -241,6 +244,10 @@
         let Tlist_Max_Tag_Length = 10
     endif
 
+    if !exists('Tlist_Cmd_Encoding')
+        let Tlist_Cmd_Encoding = 'default'
+    endif
+
     " Do not change the name of the taglist title variable. The winmanager
     " plugin relies on this name to determine the title for the taglist
     " plugin.
@@ -2363,7 +2370,12 @@
         let s:taglist_tempfile = fnamemodify(tempname(), ':h') .
                     \ '\taglist.cmd'
         if v:version >= 700
-            call writefile([ctags_cmd], s:taglist_tempfile, "b")
+            if has('iconv')
+                let ctags_cmd_codepage = iconv(ctags_cmd, 'UTF-8', g:Tlist_Cmd_Encoding)
+                call writefile([ctags_cmd_codepage], s:taglist_tempfile, 'b')
+            else
+                call writefile([ctags_cmd], s:taglist_tempfile, 'b')
+            endif
         else
             exe 'redir! > ' . s:taglist_tempfile
             silent echo ctags_cmd
```

Then I have change your code (5.0), and it seems ok.



